### PR TITLE
Change cljminecraft.blocks/extrude to pass a vector for cljminecraft.blocks/fork

### DIFF
--- a/src/cljminecraft/blocks.clj
+++ b/src/cljminecraft/blocks.clj
@@ -123,8 +123,8 @@
 
 (defaction fork
   "Run actions with ctx but don't update current ctx - effectively a subprocess"
-  ctx [actions]
-  (run-actions ctx actions)
+  ctx [& actions]
+  (apply run-actions ctx actions)
   ctx)
 
 (defaction mark
@@ -256,7 +256,7 @@
 
 (defn extrude [direction x & actions]
   (for [c (range x)]
-    (fork
+    (apply fork
      {:action :move :direction direction :distance c}
      actions)))
 


### PR DESCRIPTION
Currently, extrude passes a map and a vector of maps to fork, which unfortunately causes the call to fail since fork requires 1 argument exactly.  This change just wraps the initial call to fork and the following & args in a vector, which fork will happily handle.  This may not be perfect, but extrude works now.

What remains to be seen is if it would be better to unwrap the vector containing the maps that were passed to extrude, since I think as it stands now, fork gets handed [{:action :move :direction direction :distance c} [action_map_1 action_map_2]].
